### PR TITLE
Added license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2011 Dmytrii Nagirniak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/spinjs-rails.gemspec
+++ b/spinjs-rails.gemspec
@@ -5,6 +5,7 @@ require "spinjs-rails/version"
 Gem::Specification.new do |s|
   s.name        = "spinjs-rails"
   s.version     = Spinjs::Rails::VERSION
+  s.license     = "MIT"
   s.authors     = ["Dmytrii Nagirniak"]
   s.email       = ["dnagir@gmail.com"]
   s.homepage    = "https://github.com/dnagir/spinjs-rails"


### PR DESCRIPTION
I have been collecting a list of licenses for a project I'm working on using [LicenceFinder](https://github.com/pivotal/LicenseFinder) and I noticed that spinjs-rails doesn't include a license in it's gemspec. This is a small change which adds that in.

I set the year in the license to the year of the first commit, please check that this is accurate!
